### PR TITLE
OnClick icon triggers open tabs and added ignore url params option

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -46,11 +46,12 @@ app.service("urlList", function ($q) {
 app.service('optionService', function ($q) {
   /**
    * Service that gets and sets the options section of the UI
-   * @type {{options: {reopen: boolean}, save: Function, setReopen: Function}}
+   * @type {{options: {reopen: boolean, ignoreParams: false}, save: Function, setReopen: Function}, setIgnoreParams: Function}}
    */
   var option = {
     options:{
-      reopen:false
+      reopen:false,
+      ignoreParams:false
     },
     save:function(){
       chrome.storage.sync.set({options:option.options}, function(data){
@@ -66,8 +67,12 @@ app.service('optionService', function ($q) {
       });
       return defer.promise;
     },
-    set:function(value){
+    setReopen:function(value){
       this.options.reopen = value;
+      this.save();
+    },
+    setIgnoreParams:function(value){
+      this.options.ignoreParams = value;
       this.save();
     }
   };
@@ -96,10 +101,15 @@ app.controller('optionsCtrl', function($scope, optionService){
    */
   optionService.get().then(function(data){
     $scope.reopen = optionService.options.reopen;
+    $scope.ignoreParams = optionService.options.ignoreParams;
   });
 
   $scope.reopenChange = function(){
-    optionService.set(!$scope.reopen);
+    optionService.setReopen(!$scope.reopen);
+  }
+  
+  $scope.ignoreParamsChange = function(){
+    optionService.setIgnoreParams(!$scope.ignoreParams);
   }
 });
 

--- a/js/startup.js
+++ b/js/startup.js
@@ -202,6 +202,22 @@ var applyOptions = {
   }
 };
 
+var setupClick = {
+    notRegistered: false,
+    init: function(){
+        if(!this.notRegistered) {
+            /**
+            * set up click action
+            */
+            chrome.browserAction.onClicked.addListener(function() {
+                buildTabs.init();
+            });
+        }
+        this.notRegistered = true;
+    }
+};
+
 // start up the app crate tabs
 buildTabs.init();
 applyOptions.init();
+setupClick.init();

--- a/js/startup.js
+++ b/js/startup.js
@@ -143,13 +143,23 @@ var buildTabs = {
         if (openTabs[i].url.substr(-1) === '/') {
           openTabs[i].url =  openTabs[i].url.substr(0, openTabs[i].url.length - 1);
          }
+        
+        // remove params if configured so we can compare without them
+        if(applyOptions.options.ignoreParams) {
+          openTabs[i].url =self._removeParams(openTabs[i].url);
+        }
         open.push(openTabs[i].url);
       }
       for(var i=0; i < urlList.length; i++){
         list.push(urlList[i].url);
       }
       list.forEach(function(item){
-        if(!(open.indexOf(item)> -1)){
+        var localItem = item;        
+        // remove params if configured
+        if(applyOptions.options.ignoreParams) {
+          localItem =self._removeParams(localItem);
+        }
+        if(!(open.indexOf(localItem)> -1)){
           self.list.push({url:item});
         }
       });
@@ -159,6 +169,13 @@ var buildTabs = {
   _removeSlash:function(str){
     if (str.substr(-1) === '/') {
       str = str.substr(0, str.length - 1);
+    }
+    return str;
+  },
+  _removeParams:function(str){
+    var n = str.search(/\?/);
+    if (n >= 0) {
+      str = str.substr(0, n);
     }
     return str;
   }

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Forever pinned",
   "permissions": ["storage","tabs"],
   "background": {"scripts": ["js/q.js", "js/lodash.js", "js/startup.js"]},
   "options_page": "options.html",
   "description": "Allows you to open a set of pinned tabs when chrome starts up",
-  "version": "0.27",
+  "version": "0.28",
   "browser_action": {
     "default_title": "Click to get restore Pinned Tabs!"
   }

--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,8 @@
   "background": {"scripts": ["js/q.js", "js/lodash.js", "js/startup.js"]},
   "options_page": "options.html",
   "description": "Allows you to open a set of pinned tabs when chrome starts up",
-  "version": "0.27"
+  "version": "0.27",
+  "browser_action": {
+    "default_title": "Click to get restore Pinned Tabs!"
+  }
 }

--- a/options.html
+++ b/options.html
@@ -58,6 +58,12 @@
       </p>
       <p class="bg-warning">You will need to restart chrome before settings take effect</p>
     </form>
+    <form>
+      <p>
+      <input type="checkbox" ng-click="ignoreParamsChange()" ng-model="ignoreParams" value="{{ignoreParams}}" name="ignoreParams" />
+        <label>Ignore url parameters when comparing openned and saved tabs (site.com/?param1=value....)</label>
+      </p>
+    </form>
   </div>
   <footer>Forever pinned created by <a href="http://www.scottw.io/">scottw.io</a> source is available on <a href="https://github.com/scottwio/forever-pinned">Forever pinned</a></footer>
   </div>


### PR DESCRIPTION
- Add onClick addon icon action to re open pinned tabs on current opened window
  - This is useful when you accidentally close a tab or if you have deactivated the option to always open the pined tabs when a new windows open and you want to open them quickly in a fresh window.

- New option to remove http GET parameters from urls  …
  - If you have a tab that have a param on the url, for example: www.google.com/?u=1, the ?u=1 part will be removed when comparing with stored list of urls. this way small modifications on a page (parameters) are