### PR TITLE
Fixed ignore parameters.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -51,7 +51,7 @@ app.service('optionService', function ($q) {
   var option = {
     options:{
       reopen:false,
-      ignoreParams:false
+      ignoreParams:true
     },
     save:function(){
       chrome.storage.sync.set({options:option.options}, function(data){

--- a/js/main.js
+++ b/js/main.js
@@ -46,7 +46,7 @@ app.service("urlList", function ($q) {
 app.service('optionService', function ($q) {
   /**
    * Service that gets and sets the options section of the UI
-   * @type {{options: {reopen: boolean, ignoreParams: false}, save: Function, setReopen: Function}, setIgnoreParams: Function}}
+   * @type {{options: {reopen: false, ignoreParams: true}, save: Function, setReopen: Function}, setIgnoreParams: Function}}
    */
   var option = {
     options:{

--- a/js/startup.js
+++ b/js/startup.js
@@ -133,7 +133,8 @@ var buildTabs = {
     var self = this;
     var list = [];
     var open = [];
-    var domain = "";
+    var notOpenList = [];
+    var alreadyOpenedList = [];
 
     // reset list
     this.list = [];
@@ -153,14 +154,20 @@ var buildTabs = {
       for(var i=0; i < urlList.length; i++){
         list.push(urlList[i].url);
       }
-      list.forEach(function(item){
-        var localItem = item;        
-        // remove params if configured
-        if(applyOptions.options.ignoreParams) {
-          localItem =self._removeParams(localItem);
+      notOpenList = list.slice(0);
+      for(var i = 0; i < open.length; i++) {
+        for(var j = 0; j < list.length; j++) {
+          // Check if the URL of this open tab contains
+          // a URL from our list of tabs to open.
+          if (open[i].includes(list[j])) {
+            alreadyOpenedList.push(open[i]);
+          }
         }
-        if(!(open.indexOf(localItem)> -1)){
-          self.list.push({url:item});
+      }
+      // Remove duplicate tabs
+      open.forEach(function(openItem){
+        if(!(alreadyOpenedList.indexOf(openItem)> -1)){
+          self.list.push({url:openItem});
         }
       });
       self.create();

--- a/js/startup.js
+++ b/js/startup.js
@@ -133,7 +133,6 @@ var buildTabs = {
     var self = this;
     var list = [];
     var open = [];
-    var notOpenList = [];
     var alreadyOpenedList = [];
 
     // reset list
@@ -154,22 +153,36 @@ var buildTabs = {
       for(var i=0; i < urlList.length; i++){
         list.push(urlList[i].url);
       }
-      notOpenList = list.slice(0);
-      for(var i = 0; i < open.length; i++) {
-        for(var j = 0; j < list.length; j++) {
-          // Check if the URL of this open tab contains
-          // a URL from our list of tabs to open.
-          if (open[i].includes(list[j])) {
-            alreadyOpenedList.push(open[i]);
+      if(applyOptions.options.ignoreParams) {
+        notOpenList = list.slice(0);
+        for(var i = 0; i < open.length; i++) {
+          for(var j = 0; j < list.length; j++) {
+            // Check if the URL of this open tab contains
+            // a URL from our list of tabs to open.
+            if (open[i].includes(list[j])) {
+              alreadyOpenedList.push(list[j]);
+            }
           }
         }
+        // Now we have a list of the pinned tabs we want which are already opened.
+        // The below loop checks the total list of tabs we want
+        list.forEach(function(listItem){
+            // If the listItem isn't in the alreadyOpenedList
+            if (!(alreadyOpenedList.indexOf(listItem) >= 0)) {
+              // Add it to the list of urls to open
+              self.list.push({url:listItem});
+            }
+        });
       }
-      // Remove duplicate tabs
-      open.forEach(function(openItem){
-        if(!(alreadyOpenedList.indexOf(openItem)> -1)){
-          self.list.push({url:openItem});
-        }
-      });
+      else {
+        // If you don't want to ignore parameters just open more tabs
+        list.forEach(function(item){
+          var localItem = item;
+          if(!(open.indexOf(localItem)> -1)){
+            self.list.push({url:item});
+          }
+        });
+      }
       self.create();
     });
   },

--- a/js/startup.js
+++ b/js/startup.js
@@ -143,11 +143,6 @@ var buildTabs = {
         if (openTabs[i].url.substr(-1) === '/') {
           openTabs[i].url =  openTabs[i].url.substr(0, openTabs[i].url.length - 1);
          }
-        
-        // remove params if configured so we can compare without them
-        if(applyOptions.options.ignoreParams) {
-          openTabs[i].url =self._removeParams(openTabs[i].url);
-        }
         open.push(openTabs[i].url);
       }
       for(var i=0; i < urlList.length; i++){
@@ -189,13 +184,6 @@ var buildTabs = {
   _removeSlash:function(str){
     if (str.substr(-1) === '/') {
       str = str.substr(0, str.length - 1);
-    }
-    return str;
-  },
-  _removeParams:function(str){
-    var n = str.search(/\?/);
-    if (n >= 0) {
-      str = str.substr(0, n);
     }
     return str;
   }

--- a/options.html
+++ b/options.html
@@ -54,7 +54,7 @@
     <form>
       <p>
       <input type="checkbox" ng-click="reopenChange()" ng-model="reopen" value="{{reopen}}" name="reopen" />
-        <label>Reopen tabs when a new window is create</label>
+        <label>Reopen tabs when a new window is created</label>
       </p>
       <p class="bg-warning">You will need to restart chrome before settings take effect</p>
     </form>


### PR DESCRIPTION
This commit fixes the ignore parameters issues listed [here](https://github.com/scottwio/forever-pinned/issues/5) and [here](https://github.com/scottwio/forever-pinned/issues/2). Here's an example of the new behavior: Now on startup when the extension checks the list of tabs stored in ForeverPinned options and sees `https://mail.google.com/mail/u/0/`, then it looks at the list of opened tabs and finds `https://mail.google.com/mail/u/0/#inbox/`, it will do a string comparison checking if the opened tab contains the string from the options list. So in this example it would not open a new `https://mail.google.com/mail/u/0/` tab.

TODO: Right now this isn't using the Ignore Parameters option at all, it just does this by default.

@scottwio Thanks for making this useful extension!